### PR TITLE
feature/CT-2303 new deployment method

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -1,8 +1,11 @@
 name: CD
 
 on:
-  repository_dispatch:
-    types: [trigger-cd]
+  workflow_call:
+    inputs:
+      cluster:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -69,10 +72,7 @@ jobs:
           - ude-oslo-kommune-no
           - vlfk-no
         cluster:
-#          - aks-alpha-fint-2021-11-18
-          - aks-beta-fint-2021-11-23
-          - aks-api-fint-2022-02-08
-#          - aks-api-fint-2022-02-08
+          - ${{ inputs.cluster }}
         include:
           - org: fintlabs-no
             cluster: aks-alpha-fint-2021-11-18

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Java 17
         uses: actions/setup-java@v3.10.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Gradle Wrapper Validation

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,11 +33,3 @@ jobs:
 
       - name: Gradle Build Check
         run: ./gradlew build
-
-      - name: Trigger CD
-        if: github.ref == 'refs/heads/main'
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.GITHUBACTION_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: trigger-cd

--- a/.github/workflows/manual-deployment-all.yaml
+++ b/.github/workflows/manual-deployment-all.yaml
@@ -1,0 +1,19 @@
+# Lets user manually trigger a deployment to a selected cluster for all organizations.
+name: manual-deployment
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: 'Select an environment'
+        required: true
+        type: choice
+        options:
+          - aks-alpha-fint-2021-11-18
+          - aks-beta-fint-2021-11-23
+          - aks-api-fint-2022-02-08
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/CD.yaml
+    with:
+      cluster: ${{ github.event.inputs.cluster }}


### PR DESCRIPTION
Endrer deployment metode til å starte med workflow dispatch i stedet for merge til main hvor man kan velge environment når man deployer.

> To trigger the workflow_dispatch event, your workflow must be in the default branch.
Fra: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow

Kan dessverre altså ikke teste denne før den er merget.


Foreløpig kan den kun deploye til alle organisations.