### PR TITLE
ci: upgrade GitHub Actions to node24

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -141,7 +141,7 @@ jobs:
           fi
 
       - name: Deploy
-        uses: azure/k8s-deploy@v6
+        uses: azure/k8s-deploy@v5.0.3
         with:
           action: deploy
           manifests: ${{ steps.bake.outputs.manifestsBundle }}

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Bake manifests with Kustomize
         id: bake
-        uses: azure/k8s-bake@v3
+        uses: azure/k8s-bake@v4
         with:
           renderEngine: 'kustomize'
           kustomizationPath: 'kustomize/overlays/${{ steps.environment.outputs.result }}/${{ matrix.org }}'
@@ -118,16 +118,16 @@ jobs:
         run: |
           echo "SECRET_NAME=$(echo AKS_${{ steps.environment.outputs.result }}_FINT_GITHUB | tr '[:lower:]' '[:upper:]')" >> $GITHUB_OUTPUT
 
-      - uses: azure/login@v2
+      - uses: azure/login@v3
         with:
           creds: ${{ secrets[ steps.secretname.outputs.SECRET_NAME ] }}
 
-      - uses: azure/use-kubelogin@v1.2
+      - uses: azure/use-kubelogin@v1.3
         with:
           kubelogin-version: 'v0.0.26'
 
       - name: Set the target cluster
-        uses: azure/aks-set-context@v4
+        uses: azure/aks-set-context@v5
         with:
           cluster-name: '${{ matrix.cluster }}'
           resource-group: '${{ steps.resource-group.outputs.result }}'
@@ -141,7 +141,7 @@ jobs:
           fi
 
       - name: Deploy
-        uses: azure/k8s-deploy@v5.0.3 # Because of bug in 5.0.4, we specify 5.0.3
+        uses: azure/k8s-deploy@v6
         with:
           action: deploy
           manifests: ${{ steps.bake.outputs.manifestsBundle }}

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -106,6 +106,10 @@ jobs:
           script: return 'rg-aks-${{ steps.environment.outputs.result }}'
           result-encoding: string
 
+      - name: Update image tag
+        run: |
+          sed -i "s|image: ghcr.io/fintlabs/fint-utdanning-larling-adapter:.*|image: ${{ needs.build-and-push.outputs.tags }}|" kustomize/base/flais.yaml
+
       - name: Bake manifests with Kustomize
         id: bake
         uses: azure/k8s-bake@v4
@@ -141,9 +145,8 @@ jobs:
           fi
 
       - name: Deploy
-        uses: azure/k8s-deploy@v5.0.3
+        uses: azure/k8s-deploy@v6.0.0
         with:
           action: deploy
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
-          images: ${{ needs.build-and-push.outputs.tags }}
           namespace: ${{ matrix.org }}

--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -22,24 +22,24 @@ jobs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=sha,enable=true,priority=100,prefix=shaF-,suffix=,format=short
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Node20 is at end of life. Upgrading all actions to versions that use Node24